### PR TITLE
Allow resizing 0-length buffers

### DIFF
--- a/wail.js
+++ b/wail.js
@@ -832,11 +832,7 @@ const BufferReader = class {
     }
 
     resize() {
-        if (this.outBuffer.length == 0) {
-            throw new Error("Attempted to resize 0-length buffer");
-        }
-
-        const newBuffer = new Uint8Array(Math.ceil(this.outBuffer.length * 1.25));
+        const newBuffer = new Uint8Array(Math.ceil(8 + this.outBuffer.length * 1.25));
 
         for (let i = 0; i < this.outPos; i++) {
             newBuffer[i] = this.outBuffer[i];


### PR DESCRIPTION
I'm trying to instrument `v86.wasm` from https://copy.sh/v86/, but I can't parse it because it triggers this 0-length buffer resize condition. Being able to resize a buffer from a zero to a non-zero length seems reasonable, and it allows the desired module to be parsed. The magic value `8` (equivalent to 64 bits of space) is only about as arbitrary as the magic `1.25` scale factor, so I didn't describe it in a comment or named constant.